### PR TITLE
use-auth-email-when-possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ yarn-error.log
 
 # misc
 dist
+.idea

--- a/src/views/shared/VerifyEmail.tsx
+++ b/src/views/shared/VerifyEmail.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable import/no-cycle, jsx-a11y/label-has-associated-control */
 import React, { useState, FunctionComponent, SyntheticEvent } from 'react';
 import { Formik, Field, Form } from 'formik';
-import { useDispatch } from 'react-redux';
-
+import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from '@reach/router';
+
 import {
   ClientOnly,
   Button,
@@ -16,6 +16,7 @@ import {
 import { verifyEmail, resendSignupEmail } from '../../redux/ducks/auth';
 import { requiredField, requiredEmail } from '../../utils/validations';
 import { ActionResponseType } from '../../redux/constants';
+import { RootState } from '../../redux/ducks';
 
 declare const document: Document;
 
@@ -23,10 +24,11 @@ type VerifyEmailType = {};
 
 const VerifyEmail: FunctionComponent<VerifyEmailType & RouteComponentProps> = () => {
   const [verified, setVerified] = useState(false);
+  const authEmail = useSelector((state: RootState) => state.auth.email);
   const dispatch = useDispatch();
 
   const initialValues = {
-    email: '',
+    email: authEmail,
     digit1: '',
     digit2: '',
     digit3: '',


### PR DESCRIPTION
Agent Side
![image](https://user-images.githubusercontent.com/1385337/93603456-086b1b80-f992-11ea-8b02-259f1af6d165.png)

Buyer Side
![image](https://user-images.githubusercontent.com/1385337/93603470-0d2fcf80-f992-11ea-8cdc-47e65463aff8.png)

Empty duck/auth.email state (fyi: if no value in auth.email, initialValue for email is still '' because that's the default)
![image](https://user-images.githubusercontent.com/1385337/93603534-20db3600-f992-11ea-86be-cbdde08004f3.png)
