### PR TITLE
[REAL-nostory] - Verify refresh Token works

### DIFF
--- a/src/redux/middleware/oauth.ts
+++ b/src/redux/middleware/oauth.ts
@@ -4,7 +4,7 @@ import { isBefore } from 'date-fns';
 import { ActionResponseType, AUTH_REFRESH_ACCESS_TOKEN_ENDPOINT } from '../constants';
 import { refreshAccessToken } from '../ducks/auth';
 
-export default (store: any) => (next: any) => (action: any) => {
+export default (store: any) => (next: any) => async (action: any) => {
   const returnAction = action;
 
   // Check if the action is a RSAA middleware action
@@ -32,11 +32,11 @@ export default (store: any) => (next: any) => (action: any) => {
 
   if (returnAction[RSAA].endpoint !== AUTH_REFRESH_ACCESS_TOKEN_ENDPOINT) {
     if (isBefore(new Date(state.auth.expirationTime), new Date())) {
-      return store.dispatch(refreshAccessToken()).then((response: ActionResponseType) => {
-        if (response && !response.error) {
-          next(returnAction);
-        }
-      });
+      const response: ActionResponseType = await store.dispatch(refreshAccessToken());
+
+      if (response && !response.error) {
+        return next(returnAction);
+      }
     }
   }
 


### PR DESCRIPTION
## Ticket
No Story Number. but “Keep me logged in” aka “Refresh Tokens”:
I don’t think I am handling refreshing the access token right. I did have an interval to refresh it every 30 minutes in agent.tsx and consumer.tsx, but that only works if the website is open in a tab. The other day, I added some logic to oauth.ts to try and intercept actions in middleware and first fire off a refreshToken api call first if the expirationDate is passed, but haven’t been able to test it out if its working or not yet. I believe refresh tokens are actually valid for an hour after logging in, but you could probably fake the time in redux by hardcoding a date on authentication success. This could be moved to a new middleware if you want, but basically just need to make sure users aren’t logged out if they get a 401 (which happens in errorCatcher.ts middleware). Might just be a verification story, or could be a “rework it because tony is dumb” story :D 

## Description
- Verify that oauth middleware catches and refreshes before a user hits an endpoint so that they aren't logged out too early

## Test Setup
in auth.ts
```
case AUTHENTICATE_CREDENTIALS_SUCCESS:
  return {
    ...state,
    isLoading: false,
    hasError: false,
    isLoggedIn: true,
    failedLoginAttempts: 0,
    lockoutTimestamp: undefined,
    ...action.payload,
    expirationTime: new Date().toString(),
  };
case TOKEN_REFRESH_SUCCESS:
  const d1 = new Date();
  const d2 = new Date(d1);
  d2.setMinutes(d1.getMinutes() + 2);

  return {
    ...state,
    isLoading: false,
    hasError: false,
    tokenIsRefreshing: false,
    ...action.payload,
    expirationTime: d2.toString(),
  };
```

## Verification
I login, it refreshes immediately, I wait 2 minutes and then navigate to another page, and it refreshes again without logging me out.
![image](https://user-images.githubusercontent.com/1385337/96350761-3c1a8d80-1085-11eb-8a7a-081c7ee5a32e.png)
