### PR TITLE
Add Hide buttons to cards

### DIFF
--- a/src/components/BidDetails.tsx
+++ b/src/components/BidDetails.tsx
@@ -22,31 +22,31 @@ const BidDetails = ({ listing, bid }: { listing: ListingType; bid: BidType }) =>
             <dd>{bid.listingAgentCommission}%</dd>
             <dt>Buying Agent Commission</dt>
             <dd>{bid.buyersAgentCommission}%</dd>
-            {bid.sellerBrokerComplianceAmount && (
+            {!!bid.sellerBrokerComplianceAmount && (
               <>
                 <dt>Seller Compliance Fee</dt>
                 <dd>${bid.sellerBrokerComplianceAmount}</dd>
               </>
             )}
-            {bid.sellerPreInspectionAmount && (
+            {!!bid.sellerPreInspectionAmount && (
               <>
                 <dt>Seller Pre-Inspection</dt>
                 <dd>${bid.sellerPreInspectionAmount}</dd>
               </>
             )}
-            {bid.sellerPreCertifyAmount && (
+            {!!bid.sellerPreCertifyAmount && (
               <>
                 <dt>Seller Pre-Certification</dt>
                 <dd>${bid.sellerPreCertifyAmount}</dd>
               </>
             )}
-            {bid.sellerMovingCompanyAmount && (
+            {!!bid.sellerMovingCompanyAmount && (
               <>
                 <dt>Seller Moving Costs</dt>
                 <dd>${bid.sellerMovingCompanyAmount}</dd>
               </>
             )}
-            {bid.sellerPhotographyAmount && (
+            {!!bid.sellerPhotographyAmount && (
               <>
                 <dt>Seller Photography</dt>
                 <dd>${bid.sellerPhotographyAmount}</dd>
@@ -69,31 +69,31 @@ const BidDetails = ({ listing, bid }: { listing: ListingType; bid: BidType }) =>
           <dl>
             <dt>Total Buyer Commission</dt>
             <dd>{bid.buyerCommission}%</dd>
-            {bid.buyerBrokerComplianceAmount && (
+            {!!bid.buyerBrokerComplianceAmount && (
               <>
                 <dt>Buyer Compliance Fee</dt>
                 <dd>${bid.buyerBrokerComplianceAmount}</dd>
               </>
             )}
-            {bid.buyerInspectionAmount && (
+            {!!bid.buyerInspectionAmount && (
               <>
                 <dt>Buyer Inspection</dt>
                 <dd>${bid.buyerInspectionAmount}</dd>
               </>
             )}
-            {bid.buyerHomeWarrantyAmount && (
+            {!!bid.buyerHomeWarrantyAmount && (
               <>
                 <dt>Buyer Home Warranty</dt>
                 <dd>${bid.buyerHomeWarrantyAmount}</dd>
               </>
             )}
-            {bid.buyerAppraisalAmount && (
+            {!!bid.buyerAppraisalAmount && (
               <>
                 <dt>Buyer Appraisal</dt>
                 <dd>${bid.buyerAppraisalAmount}</dd>
               </>
             )}
-            {bid.buyerMovingCompanyAmount && (
+            {!!bid.buyerMovingCompanyAmount && (
               <>
                 <dt>Buyer Moving Costs</dt>
                 <dd>${bid.buyerMovingCompanyAmount}</dd>

--- a/src/components/ListingCard.tsx
+++ b/src/components/ListingCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'gatsby';
 import styled from 'styled-components';
 import TextTruncate from 'react-text-truncate';
 import { useDispatch } from 'react-redux';
-import { FaEyeSlash } from 'react-icons/fa';
+import { FaTrashAlt } from 'react-icons/fa';
 
 import Button from './Button';
 import Heading from './Heading';
@@ -12,7 +12,7 @@ import Modal from './Modal';
 import Row from './Row';
 import Column from './Column';
 
-import { brandSuccess, brandDanger, textColor, white, brandTertiary } from '../styles/color';
+import { brandSuccess, brandDanger, textColor, white } from '../styles/color';
 import { halfSpacer, baseSpacer, borderRadius } from '../styles/size';
 import { z1Shadow, baseBorderStyle } from '../styles/mixins';
 import FlexContainer from './FlexContainer';
@@ -60,13 +60,13 @@ const ListingCardHeader = styled.div`
   border-bottom: ${baseBorderStyle};
 `;
 
-const CardType = styled.span`
-  background-color: ${brandTertiary};
-  border-radius: ${borderRadius};
-  color: ${white};
-  padding: 0 ${halfSpacer};
-  text-transform: capitalize;
-`;
+// const CardType = styled.span`
+//   background-color: ${brandTertiary};
+//   border-radius: ${borderRadius};
+//   color: ${white};
+//   padding: 0 ${halfSpacer};
+//   text-transform: capitalize;
+// `;
 
 const ListingCardBody = styled.div`
   padding: ${halfSpacer} ${baseSpacer};
@@ -80,10 +80,6 @@ const ListingCardBody = styled.div`
 const ListingCardFooter = styled.div`
   border-top: ${baseBorderStyle};
   padding: ${halfSpacer};
-`;
-
-const StyledHideIcon = styled(FaEyeSlash)`
-  cursor: pointer;
 `;
 
 const ListingCard: FunctionComponent<ListingCardProps> = ({ listing, listingType, isHideable }) => {
@@ -109,42 +105,51 @@ const ListingCard: FunctionComponent<ListingCardProps> = ({ listing, listingType
               }, 5000);
             }}
           />
-          {isHideable && (
-            <>
-              <Modal toggleModal={() => setModalIsOpen(false)} isOpen={modalIsOpen}>
-                <Heading styledAs="title">Hide Listing?</Heading>
-                <p>Are you sure you want to hide the listing?</p>
-                <Row>
-                  <Column xs={6}>
-                    <Button
-                      type="button"
-                      onClick={() => setModalIsOpen(false)}
-                      color="primaryOutline"
-                      block
-                    >
-                      Cancel
-                    </Button>
-                  </Column>
-                  <Column xs={6}>
-                    <Button
-                      type="button"
-                      onClick={async () => {
-                        if (listing.id != null) {
-                          dispatch(toggleListingVisibility(listing.id));
-                        }
-                      }}
-                      block
-                      color="danger"
-                    >
-                      Hide
-                    </Button>
-                  </Column>
-                </Row>
-              </Modal>
-              <StyledHideIcon onClick={() => setModalIsOpen(true)} />
-            </>
-          )}
-          <CardType>{listing.type === 'buyerSeller' ? 'Buyer & Seller' : listing.type}</CardType>
+          <div>
+            {/* <CardType>{listing.type === 'buyerSeller' ? 'Buyer & Seller' : listing.type}</CardType> */}
+            {isHideable && (
+              <>
+                <Modal toggleModal={() => setModalIsOpen(false)} isOpen={modalIsOpen}>
+                  <Heading styledAs="title">Hide Listing?</Heading>
+                  <p>Are you sure you want to hide the listing?</p>
+                  <Row>
+                    <Column xs={6}>
+                      <Button
+                        type="button"
+                        onClick={() => setModalIsOpen(false)}
+                        color="primaryOutline"
+                        block
+                      >
+                        Cancel
+                      </Button>
+                    </Column>
+                    <Column xs={6}>
+                      <Button
+                        type="button"
+                        onClick={async () => {
+                          if (listing.id != null) {
+                            dispatch(toggleListingVisibility(listing.id));
+                          }
+                        }}
+                        block
+                        color="danger"
+                      >
+                        Hide
+                      </Button>
+                    </Column>
+                  </Row>
+                </Modal>
+                <Button
+                  type="button"
+                  onClick={() => setModalIsOpen(true)}
+                  iconLeft={<FaTrashAlt />}
+                  color="text"
+                >
+                  Remove Listing
+                </Button>
+              </>
+            )}
+          </div>
         </FlexContainer>
       </ListingCardHeader>
       <ListingCardBody>

--- a/src/redux/configureStore.ts
+++ b/src/redux/configureStore.ts
@@ -48,7 +48,7 @@ const makeConfiguredStore = (reducer: any, initialState: any) => {
   const persistConfig = {
     key: 'realty-offer',
     storage,
-    whitelist: ['auth', 'consumer', 'dropdowns'],
+    whitelist: ['auth', 'consumer', 'dropdowns', 'listings'],
   };
   const persistedReducer = persistReducer(persistConfig, reducer);
 

--- a/src/redux/ducks/index.ts
+++ b/src/redux/ducks/index.ts
@@ -1,6 +1,4 @@
 import { combineReducers } from 'redux';
-import { persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import admin from './admin';
 import agent from './agent';
@@ -12,13 +10,6 @@ import globalAlerts from './globalAlerts';
 import listings from './listings';
 import user from './user';
 
-// Whitelist the hidden ID array to keep listings hidden on refresh
-const listingConfig = {
-  key: 'listings',
-  storage,
-  whitelist: ['hiddenListingIds'],
-};
-
 const rootReducer = combineReducers({
   admin,
   agent,
@@ -27,7 +18,7 @@ const rootReducer = combineReducers({
   dropdowns,
   fortis,
   globalAlerts,
-  listings: persistReducer(listingConfig, listings),
+  listings,
   user,
 });
 

--- a/src/redux/ducks/listings.ts
+++ b/src/redux/ducks/listings.ts
@@ -119,6 +119,7 @@ export default (
         ...initialState,
         countyFilter: state.countyFilter,
         salesAreaOnly: state.salesAreaOnly,
+        hiddenListingIds: state.hiddenListingIds,
       };
     default:
       return state;

--- a/src/views/agent/Authenticated/Listings/New.tsx
+++ b/src/views/agent/Authenticated/Listings/New.tsx
@@ -54,17 +54,16 @@ const NewListings: FunctionComponent<RouteComponentProps> = () => {
       return obj;
     });
 
-  const isFilteredByCounty = listings.countyFilter !== 'All Counties';
+  const isFilteredByCounty =
+    listings.countyFilter !== 'All Counties' && listings.countyFilter !== '';
   const isFilteredBySalesArea = listings.salesAreaOnly;
 
+  let listingsToShow = newListings;
+
+  // Remove listings hidden by the user
+  listingsToShow = listingsToShow.filter(({ id }) => id != null && !hiddenListingIds.includes(id));
+
   const filteredListings = () => {
-    let listingsToShow = newListings;
-
-    // Remove listings hidden by the user
-    listingsToShow = listingsToShow.filter(
-      ({ id }) => id != null && !hiddenListingIds.includes(id)
-    );
-
     if (isFilteredByCounty) {
       const sellersCityMatchesByCounty = listingsToShow.filter(
         (l) => l.sellersCity?.countyId === Number(listings.countyFilter)
@@ -93,7 +92,7 @@ const NewListings: FunctionComponent<RouteComponentProps> = () => {
   };
 
   const initialValues = {
-    countyFilter: listings.countyFilter || 'All Counties',
+    countyFilter: listings.countyFilter === '' ? 'All Counties' : listings.countyFilter,
     salesAreaOnly: listings.salesAreaOnly || false,
   };
 
@@ -116,7 +115,9 @@ const NewListings: FunctionComponent<RouteComponentProps> = () => {
           }
           resetForm({
             values: {
-              countyFilter: values.salesAreaOnly ? 'All Counties' : values.countyFilter,
+              countyFilter: values.salesAreaOnly
+                ? 'All Counties'
+                : values.countyFilter || 'All Counties',
               salesAreaOnly: values.salesAreaOnly,
             },
           });
@@ -147,7 +148,7 @@ const NewListings: FunctionComponent<RouteComponentProps> = () => {
               </Column>
             </Row>
             {isLoading && <ListingCardsLoader />}
-            {newListings && newListings.length > 0 && !isLoading && (
+            {listingsToShow && listingsToShow.length > 0 && !isLoading && (
               <Row>
                 {filteredListings()?.map((listing) => (
                   <Column sm={6} lg={4} key={listing.id}>
@@ -171,7 +172,7 @@ const NewListings: FunctionComponent<RouteComponentProps> = () => {
                 }}
               />
             )}
-            {!isFilteredByCounty && newListings && newListings.length === 0 && !isLoading && (
+            {!isFilteredByCounty && listingsToShow && listingsToShow.length === 0 && !isLoading && (
               <EmptyListingsView
                 title="There are no new listings in your current sales area."
                 buttonText="Add More Cities"


### PR DESCRIPTION
This PR adds a new action to add a new listing to a list of listings to not list. This is persisted through it's own persist config to keep the listings not listed on refresh. There's a typescript error that is seemingly impossible to fix, since there should be a `_persist` object on the ListingType,
```ts
interface PersistState {
  version: number;
  rehydrated: boolean;
}
```

but if that's included, the rehydrate action times out and resets the state to empty. 